### PR TITLE
Pytest with coverage, sonarqube

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,15 @@ jobs:
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip
-        python setup.py install
-        pip install pytest
-    - name: Reinstall pyasp
-      run: |
+        python setup.py develop
         pip uninstall pyasp --yes
         pip install pyasp==1.4.3 --no-cache-dir
+
+    - name: Build meneco
+      run: |
+        python setup.py install
+
     - name: Test using pytest
-      run: pytest
+      run: |
+        pip install pytest pytest-cov
+        pytest --cov --cov-report=term-missing -vv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,5 @@ jobs:
       run: |
         pip uninstall pyasp --yes
         pip install pyasp==1.4.3 --no-cache-dir
-    - name: Run on toy example
-      run: |
-        cd toy
-        meneco -d draft.sbml -s seeds.sbml -t targets.sbml -r repair.sbml  2>&1 | tee output.log
-        tail -n2 output.log | sort | fmt | sed 's/"//g' | tee output_union.log | diff --report-identical-files - expected_union.log
-
+    - name: Test using pytest
+      run: pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,5 @@ jobs:
       run: |
         pip install pytest pytest-cov
         pytest --cov --cov-report=term-missing -vv
+        coverage report
+        coverage xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up python 
+    - name: Set up python
       uses: actions/setup-python@v1
       with: 
         python-version: 3.8
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python setup.py install
+        pip install pytest
     - name: Reinstall pyasp
       run: |
         pip uninstall pyasp --yes

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# Files to ignore for meneco ------
+
+
+# Standard os ------------------------
+
+*~
+._*
+.DS_Store
+.directory
+
+
+# Generated for ASP ------------------
+
+asp_py_lextab.py
+asp_py_parsetab.py
+
+asp_py_lextab.py
+	asp_py_parsetab.py
+# Python -----------------------------
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+dist/
+eggs/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+toxtests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Sphinx documentation
+docs/_build/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# SonarQube
+/.scannerwork

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
     package_data={'meneco': ['encodings/*.lp']},
     # scripts          = ['meneco.py'],
     entry_points={'console_scripts': ['meneco = meneco.__main__:main_meneco']},
+    tests_requires=['pytest'],
     install_requires=['pyasp == 1.4.3']
 )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,22 @@
+# SonarQube endpoint
+sonar.host.url=https://sonarqube.inria.fr/sonarqube
+
+# Use login token from environment
+# sonar.login=
+
+# Unique project key
+sonar.projectKey=pleiade:meneco:branch:dev
+
+# Version for leak interval
+sonar.projectVersion=1.5.2
+
+# Paths to sources
+sonar.sources=meneco, tests
+
+# Language
+sonar.language=py
+sonar.exclusions=**/*.pyc,**/*.md,tests/**/fixtures/**,**/*.lp
+
+# Coverage
+sonar.python.coverage.reportPath=coverage.xml
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/test_run_meneco_toy.py
+++ b/tests/test_run_meneco_toy.py
@@ -1,0 +1,36 @@
+# Feature: meneco
+# 	Script to run meneco
+#
+# Scenario: Run meneco on toy example
+# 	Given toy example
+# 	And output directory
+# 	When run meneco
+# 	Then have repaired network
+# 	And it contains expected reactions
+
+import os
+from pathlib import Path  # noqa: F401
+from pyasp.term import *
+import tempfile
+
+import meneco
+
+def reaction_ids(prediction):
+    return set([p.arg(0) for p in prediction if p.pred() == "xreaction"])
+    
+def test_run_meneco_toy():
+    toy = Path('.') / "toy"
+
+    unprod, recon_targets, one_min, intersection, union, enum = meneco.run_meneco(
+        str(toy / "draft.sbml"),
+        str(toy / "seeds.sbml"),
+        str(toy / "targets.sbml"),
+        str(toy / "repair.sbml"),
+        False
+    )
+
+    assert len(unprod) == 31
+    assert reaction_ids(recon_targets) == set([])
+    assert reaction_ids(one_min) == set(['"R_CU2tpp"', '"R_CLt3_2pp"'])
+    assert reaction_ids(intersection) == set(['"R_CU2tpp"', '"R_CLt3_2pp"'])
+    assert reaction_ids(union) == set(['"R_CU2tpp"', '"R_CLt3_2pp"'])

--- a/tests/test_run_meneco_toy.py
+++ b/tests/test_run_meneco_toy.py
@@ -8,25 +8,24 @@
 # 	Then have repaired network
 # 	And it contains expected reactions
 
-import os
 from pathlib import Path  # noqa: F401
-from pyasp.term import *
-import tempfile
 
 import meneco
 
+
 def reaction_ids(prediction):
     return set([p.arg(0) for p in prediction if p.pred() == "xreaction"])
-    
+
+
 def test_run_meneco_toy():
-    toy = Path('.') / "toy"
+    toy = Path(".") / "toy"
 
     unprod, recon_targets, one_min, intersection, union, enum = meneco.run_meneco(
         str(toy / "draft.sbml"),
         str(toy / "seeds.sbml"),
         str(toy / "targets.sbml"),
         str(toy / "repair.sbml"),
-        False
+        False,
     )
 
     assert len(unprod) == 31


### PR DESCRIPTION
Run pytest with code coverage, reported in `coverage.xml`.

Add `sonar-project.properties` control file so that coverage results can be integrated with code quality. Assuming `SONAR_AUTH_TOKEN` is set, run using

```
sonar-scanner -Dsonar.login=$SONAR_AUTH_TOKEN
```